### PR TITLE
Remove noisy (debug?) printing from server startup

### DIFF
--- a/server.go
+++ b/server.go
@@ -129,7 +129,6 @@ func NewServer(c *Config) (*Server, error) {
 		if method.Name[0] > 'a' && method.Name[0] < 'z' {
 			continue
 		}
-		println(method.Name)
 		handlerFn, err := srv.createHandlerFn(c.handler, &method.Func)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This is kind of distracting on server startup, and I'm not sure of the value. I have only two commands implemented (`GET` and `SET`), and I don't find this output useful in the slightest.

Happy to learn if there's a good reason for it being there other than debugging.
