### PR TITLE
make it work with redis-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/dotcloud/go-redis-server.png)](https://travis-ci.org/dotcloud/go-redis-server)
+[![Build Status](https://travis-ci.org/docker/go-redis-server.png)](https://travis-ci.org/dotcloud/go-redis-server)
 
 Redis server protocol library
 =============================

--- a/parser.go
+++ b/parser.go
@@ -21,7 +21,7 @@ func parseRequest(conn io.ReadCloser) (*Request, error) {
 
 	// Multiline request:
 	if line[0] == '*' {
-		if _, err := fmt.Sscanf(line, "*%d\r", &argsCount); err != nil {
+		if _, err := fmt.Sscanf(line, "*%d\r\n", &argsCount); err != nil {
 			return nil, malformed("*<numberOfArguments>", line)
 		}
 		// All next lines are pairs of:
@@ -71,7 +71,7 @@ func readArgument(r *bufio.Reader) ([]byte, error) {
 		return nil, malformed("$<argumentLength>", line)
 	}
 	var argSize int
-	if _, err := fmt.Sscanf(line, "$%d\r", &argSize); err != nil {
+	if _, err := fmt.Sscanf(line, "$%d\r\n", &argSize); err != nil {
 		return nil, malformed("$<argumentSize>", line)
 	}
 


### PR DESCRIPTION
I think the fmt.Sscanf or Readline implementation might have changed, but the server didn't work for me (go 1.5) until I changed the Sscanf to include \r\n.

$go version
go version go1.5 darwin/amd64
$redis-cli -v
redis-cli 3.0.1
