### PR TITLE
Bugfix: fmt.Sscanf need indicate '\r\n' explicitly

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -21,7 +21,7 @@ func parseRequest(conn io.ReadCloser) (*Request, error) {
 
 	// Multiline request:
 	if line[0] == '*' {
-		if _, err := fmt.Sscanf(line, "*%d\r", &argsCount); err != nil {
+		if _, err := fmt.Sscanf(line, "*%d\r\n", &argsCount); err != nil {
 			return nil, malformed("*<numberOfArguments>", line)
 		}
 		// All next lines are pairs of:
@@ -71,7 +71,7 @@ func readArgument(r *bufio.Reader) ([]byte, error) {
 		return nil, malformed("$<argumentLength>", line)
 	}
 	var argSize int
-	if _, err := fmt.Sscanf(line, "$%d\r", &argSize); err != nil {
+	if _, err := fmt.Sscanf(line, "$%d\r\n", &argSize); err != nil {
 		return nil, malformed("$<argumentSize>", line)
 	}
 

--- a/parser.go
+++ b/parser.go
@@ -8,8 +8,7 @@ import (
 	"strings"
 )
 
-func parseRequest(conn io.ReadCloser) (*Request, error) {
-	r := bufio.NewReader(conn)
+func parseRequest(r *bufio.Reader) (*Request, error) {
 	// first line of redis request should be:
 	// *<number of arguments>CRLF
 	line, err := r.ReadString('\n')
@@ -43,7 +42,6 @@ func parseRequest(conn io.ReadCloser) (*Request, error) {
 		return &Request{
 			Name: strings.ToLower(string(firstArg)),
 			Args: args,
-			Body: conn,
 		}, nil
 	}
 
@@ -59,7 +57,6 @@ func parseRequest(conn io.ReadCloser) (*Request, error) {
 	return &Request{
 		Name: strings.ToLower(string(fields[0])),
 		Args: args,
-		Body: conn,
 	}, nil
 
 }

--- a/request.go
+++ b/request.go
@@ -1,16 +1,12 @@
 package redis
 
-import (
-	"io"
-	"strconv"
-)
+import "strconv"
 
 type Request struct {
 	Name       string
 	Args       [][]byte
 	Host       string
 	ClientChan chan struct{}
-	Body       io.ReadCloser
 }
 
 func (r *Request) HasArgument(index int) bool {

--- a/server.go
+++ b/server.go
@@ -7,6 +7,7 @@ package redis
 import (
 	"bufio"
 	"fmt"
+	"golang.org/x/net/netutil"
 	"io"
 	"io/ioutil"
 	"net"
@@ -20,7 +21,8 @@ type Server struct {
 	methods      map[string]HandlerFn
 }
 
-func (srv *Server) ListenAndServe() error {
+// ListenAndServe receives an argument maxConnection, which limit max connection it can accept simultaneous, passing maxConnection <= 0 means no limit.
+func (srv *Server) ListenAndServe(maxConnection int) error {
 	addr := srv.Addr
 	if srv.Proto == "" {
 		srv.Proto = "tcp"
@@ -33,6 +35,9 @@ func (srv *Server) ListenAndServe() error {
 	l, e := net.Listen(srv.Proto, addr)
 	if e != nil {
 		return e
+	}
+	if maxConnection > 0 {
+		l = netutil.LimitListener(l, maxConnection)
 	}
 	return srv.Serve(l)
 }

--- a/server.go
+++ b/server.go
@@ -5,6 +5,7 @@
 package redis
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -88,8 +89,9 @@ func (srv *Server) ServeClient(conn net.Conn) (err error) {
 		clientAddr = co.RemoteAddr().String()
 	}
 
+	br := bufio.NewReader(conn)
 	for {
-		request, err := parseRequest(conn)
+		request, err := parseRequest(br)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The older version think '*2\r\n'  as invalid input when parsing multiline command.

fmt.SScanf must indicate '\r\n' explicitly now.