### PR TITLE
bugfix: use same bufio.Reader for all requests in one connection.

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -8,8 +8,7 @@ import (
 	"strings"
 )
 
-func parseRequest(conn io.ReadCloser) (*Request, error) {
-	r := bufio.NewReader(conn)
+func parseRequest(r *bufio.Reader) (*Request, error) {
 	// first line of redis request should be:
 	// *<number of arguments>CRLF
 	line, err := r.ReadString('\n')
@@ -43,7 +42,6 @@ func parseRequest(conn io.ReadCloser) (*Request, error) {
 		return &Request{
 			Name: strings.ToLower(string(firstArg)),
 			Args: args,
-			Body: conn,
 		}, nil
 	}
 
@@ -59,7 +57,6 @@ func parseRequest(conn io.ReadCloser) (*Request, error) {
 	return &Request{
 		Name: strings.ToLower(string(fields[0])),
 		Args: args,
-		Body: conn,
 	}, nil
 
 }

--- a/request.go
+++ b/request.go
@@ -1,16 +1,12 @@
 package redis
 
-import (
-	"io"
-	"strconv"
-)
+import "strconv"
 
 type Request struct {
 	Name       string
 	Args       [][]byte
 	Host       string
 	ClientChan chan struct{}
-	Body       io.ReadCloser
 }
 
 func (r *Request) HasArgument(index int) bool {

--- a/server.go
+++ b/server.go
@@ -5,6 +5,7 @@
 package redis
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -88,8 +89,9 @@ func (srv *Server) ServeClient(conn net.Conn) (err error) {
 		clientAddr = co.RemoteAddr().String()
 	}
 
+	br := bufio.NewReader(conn)
 	for {
-		request, err := parseRequest(conn)
+		request, err := parseRequest(br)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
My colleague found that this code do not work well in PIPELINE mode.

The reason is that the old code create `bufio.Reader` for each request. When using pipeline mode, `bufio.Reader` may eat some input data which belong to next request.

The old code works well when client waits for server response before sending next request. While Reader is still trying to read more data to its buffer, there's nothing more but exactly current request  data in conn.